### PR TITLE
changed input type from datetime-local to datetime

### DIFF
--- a/eta-company-calendar-frontend/src/app/calendar/modals/meeting-create.component.html
+++ b/eta-company-calendar-frontend/src/app/calendar/modals/meeting-create.component.html
@@ -34,7 +34,7 @@
           <mat-label >{{ 'meeting.startingTime' | translate }} *</mat-label>
           <input
             matInput
-            type="datetime-local" autocomplete="off"
+            type="datetime" autocomplete="off"
             formControlName="startingTime" 
             [max]="formMaxStartTime"
             [owlDateTime]="dt1" [owlDateTimeTrigger]="dt1" >
@@ -45,7 +45,7 @@
         <mat-form-field>
           <mat-label >{{ 'meeting.finishTime' | translate }} *</mat-label>
           <input matInput
-            type="datetime-local" autocomplete="off"
+            type="datetime" autocomplete="off"
             formControlName="finishTime"
             [min]="formMinFinishTime"
             [owlDateTime]="dt2" [owlDateTimeTrigger]="dt2">


### PR DESCRIPTION
#113
A `MeetingCreate` komponensben a dátum input mezőt meg változtattam `datetime-local`-ról `datetime`-ra, mert a chrome nem jelenítette meg az oda beírt dátumot.