### PR TITLE
I128 recurring meeting backend

### DIFF
--- a/eta-company-calendar-backend/src/main/java/hu/flowacademy/companycalendar/model/Meeting.java
+++ b/eta-company-calendar-backend/src/main/java/hu/flowacademy/companycalendar/model/Meeting.java
@@ -1,5 +1,7 @@
 package hu.flowacademy.companycalendar.model;
 
+import javax.persistence.CascadeType;
+import javax.persistence.OneToOne;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -36,6 +38,9 @@ public class Meeting {
 
   @Enumerated(value = EnumType.STRING)
   private Recurring recurring;
+
+  @OneToOne(cascade = CascadeType.PERSIST)
+  private RRule rrule;
 
   private Long startingTime;
 

--- a/eta-company-calendar-backend/src/main/java/hu/flowacademy/companycalendar/model/RRule.java
+++ b/eta-company-calendar-backend/src/main/java/hu/flowacademy/companycalendar/model/RRule.java
@@ -1,0 +1,36 @@
+package hu.flowacademy.companycalendar.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import javax.persistence.CascadeType;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.OneToOne;
+import javax.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class RRule {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @OneToOne(mappedBy = "rrule", cascade = CascadeType.ALL)
+  @JsonIgnore
+  private Meeting meeting;
+
+  @NotBlank
+  private String rrule;
+
+  private Long dtstart = Long.MIN_VALUE;
+
+  private Long until = Long.MAX_VALUE;
+
+}

--- a/eta-company-calendar-backend/src/main/java/hu/flowacademy/companycalendar/model/RRule.java
+++ b/eta-company-calendar-backend/src/main/java/hu/flowacademy/companycalendar/model/RRule.java
@@ -34,4 +34,6 @@ public class RRule {
   private Long dtstart = Long.MIN_VALUE;
 
   private Long until = Long.MAX_VALUE;
+
+  private Long duration;
 }

--- a/eta-company-calendar-backend/src/main/java/hu/flowacademy/companycalendar/model/RRule.java
+++ b/eta-company-calendar-backend/src/main/java/hu/flowacademy/companycalendar/model/RRule.java
@@ -32,5 +32,4 @@ public class RRule {
   private Long dtstart = Long.MIN_VALUE;
 
   private Long until = Long.MAX_VALUE;
-
 }

--- a/eta-company-calendar-backend/src/main/java/hu/flowacademy/companycalendar/model/RRule.java
+++ b/eta-company-calendar-backend/src/main/java/hu/flowacademy/companycalendar/model/RRule.java
@@ -9,6 +9,7 @@ import javax.persistence.Id;
 import javax.persistence.OneToOne;
 import javax.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
@@ -16,6 +17,7 @@ import lombok.NoArgsConstructor;
 @Data
 @AllArgsConstructor
 @NoArgsConstructor
+@Builder
 public class RRule {
 
   @Id

--- a/eta-company-calendar-backend/src/main/java/hu/flowacademy/companycalendar/model/dto/MeetingCreateDTO.java
+++ b/eta-company-calendar-backend/src/main/java/hu/flowacademy/companycalendar/model/dto/MeetingCreateDTO.java
@@ -2,6 +2,7 @@ package hu.flowacademy.companycalendar.model.dto;
 
 import hu.flowacademy.companycalendar.model.Location;
 import hu.flowacademy.companycalendar.model.Meeting;
+import hu.flowacademy.companycalendar.model.RRule;
 import hu.flowacademy.companycalendar.model.Recurring;
 import hu.flowacademy.companycalendar.model.User;
 import java.util.ArrayList;
@@ -23,6 +24,7 @@ public class MeetingCreateDTO {
   private Location location;
   private String otherLocation;
   private Recurring recurring;
+  private RRule rrule;
   private Long startingTime;
   private Long finishTime;
   private String createdBy;

--- a/eta-company-calendar-backend/src/main/java/hu/flowacademy/companycalendar/model/dto/MeetingListItemDTO.java
+++ b/eta-company-calendar-backend/src/main/java/hu/flowacademy/companycalendar/model/dto/MeetingListItemDTO.java
@@ -1,6 +1,7 @@
 package hu.flowacademy.companycalendar.model.dto;
 
 import hu.flowacademy.companycalendar.model.Meeting;
+import hu.flowacademy.companycalendar.model.RRule;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -16,6 +17,7 @@ public class MeetingListItemDTO {
   private String title;
   private Long startingTime;
   private Long finishTime;
+  private RRule rrule;
 
   public MeetingListItemDTO(Meeting meeting) {
     BeanUtils.copyProperties(meeting, this);

--- a/eta-company-calendar-backend/src/main/java/hu/flowacademy/companycalendar/repository/MeetingRepository.java
+++ b/eta-company-calendar-backend/src/main/java/hu/flowacademy/companycalendar/repository/MeetingRepository.java
@@ -18,7 +18,7 @@ public interface MeetingRepository extends JpaRepository<Meeting, Long> {
       + " (m.startingTime BETWEEN ?2 and ?3"
       + " OR ?2 BETWEEN rrule.dtstart and rrule.until"
       + " OR ?3 BETWEEN rrule.dtstart and rrule.until)")
-  List<Meeting> findByUserIdAndTimeRange(Long userId, Long startingTimeFrom, Long StartingTimeTo);
+  List<Meeting> findByUserIdAndTimeRange(Long userId, Long startingTimeFrom, Long startingTimeTo);
 
   @Query("SELECT DISTINCT m FROM "
           + "Meeting m LEFT OUTER JOIN m.requiredAttendants r LEFT OUTER JOIN m.optionalAttendants o "

--- a/eta-company-calendar-backend/src/main/java/hu/flowacademy/companycalendar/repository/MeetingRepository.java
+++ b/eta-company-calendar-backend/src/main/java/hu/flowacademy/companycalendar/repository/MeetingRepository.java
@@ -9,10 +9,15 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface MeetingRepository extends JpaRepository<Meeting, Long> {
 
-  @Query("SELECT DISTINCT m FROM "
-      + "Meeting m LEFT OUTER JOIN m.requiredAttendants r LEFT OUTER JOIN m.optionalAttendants o "
+  @Query("SELECT DISTINCT m FROM Meeting m "
+      + "LEFT OUTER JOIN m.requiredAttendants r "
+      + "LEFT OUTER JOIN m.optionalAttendants o "
+      + "LEFT OUTER JOIN m.rrule rrule "
       + "WHERE (m.createdBy.id = ?1 OR r.id = ?1 OR o.id = ?1) "
-      + "AND m.startingTime BETWEEN ?2 and ?3")
+      + "AND"
+      + " (m.startingTime BETWEEN ?2 and ?3"
+      + " OR rrule.dtstart BETWEEN ?2 and ?3"
+      + " OR rrule.until BETWEEN ?2 and ?3)")
   List<Meeting> findByUserIdAndTimeRange(Long userId, Long startingTimeFrom, Long StartingTimeTo);
 
   @Query("SELECT DISTINCT m FROM "

--- a/eta-company-calendar-backend/src/main/java/hu/flowacademy/companycalendar/repository/MeetingRepository.java
+++ b/eta-company-calendar-backend/src/main/java/hu/flowacademy/companycalendar/repository/MeetingRepository.java
@@ -16,8 +16,8 @@ public interface MeetingRepository extends JpaRepository<Meeting, Long> {
       + "WHERE (m.createdBy.id = ?1 OR r.id = ?1 OR o.id = ?1) "
       + "AND"
       + " (m.startingTime BETWEEN ?2 and ?3"
-      + " OR rrule.dtstart BETWEEN ?2 and ?3"
-      + " OR rrule.until BETWEEN ?2 and ?3)")
+      + " OR ?2 BETWEEN rrule.dtstart and rrule.until"
+      + " OR ?3 BETWEEN rrule.dtstart and rrule.until)")
   List<Meeting> findByUserIdAndTimeRange(Long userId, Long startingTimeFrom, Long StartingTimeTo);
 
   @Query("SELECT DISTINCT m FROM "

--- a/eta-company-calendar-backend/src/main/java/hu/flowacademy/companycalendar/utils/InitDataLoader.java
+++ b/eta-company-calendar-backend/src/main/java/hu/flowacademy/companycalendar/utils/InitDataLoader.java
@@ -84,7 +84,8 @@ public class InitDataLoader {
             .rrule(RRule.builder()
                 .rrule(rrule)
                 .dtstart(1580518800000L)
-                .until(1612051200000L).build())
+                .until(1612051200000L)
+                .duration(7200000L).build())
             .build());
     }
 

--- a/eta-company-calendar-backend/src/main/java/hu/flowacademy/companycalendar/utils/InitDataLoader.java
+++ b/eta-company-calendar-backend/src/main/java/hu/flowacademy/companycalendar/utils/InitDataLoader.java
@@ -2,6 +2,7 @@ package hu.flowacademy.companycalendar.utils;
 
 import hu.flowacademy.companycalendar.model.Location;
 import hu.flowacademy.companycalendar.model.Meeting;
+import hu.flowacademy.companycalendar.model.RRule;
 import hu.flowacademy.companycalendar.model.Recurring;
 import hu.flowacademy.companycalendar.model.Reminder;
 import hu.flowacademy.companycalendar.model.User;
@@ -71,7 +72,20 @@ public class InitDataLoader {
                 .optionalAttendants(List.of(testUsers.get(0)))
                 .build()).collect(Collectors.toList())
         );
-        
+        var rrule = "DTSTART:20200201T010000Z\n"
+            + "RRULE:FREQ=WEEKLY;INTERVAL=1;BYDAY=MO,TU,FR;UNTIL=20210131T000000Z";
+        meetingRepository.save(Meeting.builder()
+            .title("recurring meeting")
+            .description("a meeting every Monday and Friday")
+            .location(Location.MARKS_OFFICE)
+            .createdAt(System.currentTimeMillis())
+            .createdBy(testUsers.get(0))
+            .requiredAttendants(List.of(testUsers.get(1)))
+            .rrule(RRule.builder()
+                .rrule(rrule)
+                .dtstart(1580518800000L)
+                .until(1612051200000L).build())
+            .build());
     }
 
     public void createReminder() throws ParseException {


### PR DESCRIPTION
#128 -hoz létrehoztam egy entitást az események ismétlődéséhez, és módosítottam a `findByUserIdAndTimeRange` query-t hogy az ismétlődő meeting-eket is szűrje.

https://github.com/jakubroztocil/rrule
Frontenden az rrule npm csomagot szeretném használni az ismétlődésekhez, amit a fullcalendar is támogat. Ez a csomag legenerál egy string-et, ami alapján a fullcalendar meg tudja jeleníteni az esemény ismétlődését. Ezt a string-et szeretném backenden eltárolni az `RRule` entitásban
